### PR TITLE
Fix a compile error against Qt 5.11

### DIFF
--- a/src/main/shutdownprompt.cpp
+++ b/src/main/shutdownprompt.cpp
@@ -1,3 +1,5 @@
+#include <QStyle>
+
 #include "shutdownprompt.h"
 #include "ui_shutdownprompt.h"
 


### PR DESCRIPTION
Qt 5.11 will be released in a couple of weeks, there's a minor compilation error when using it.

Presumably, there'll be a PPA made available once it's released, so we can upgrade Travis then, too.